### PR TITLE
Add setup.py for local development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="fast_reid",
+    version="0.1",
+    author="JDAI-CV",
+    url="https://github.com/JDAI-CV/fast-reid",
+    packages=find_packages(exclude=("docs", "tests")),
+    python_requires=">=3.6",
+    install_requries=[
+        "pytorch>=1.6",
+        "torchvision",
+        "yacs",
+        "Cython",
+        "tensorboard",
+        "gdown",
+        "sklearn",
+        "termcolor",
+        "tabulate",
+        "faiss",
+    ]
+
+)


### PR DESCRIPTION
Since fast-reid is a project under rapid iteration, conflicts often happens.  

We suggest adding a `setup.py` file in github repo, and maintaining two private repo in local development. 

- One repo is used to keep up with github repo, install fastreid with `pip install git@private-git:JDAI-CV/fast-reid.git ` 
- the other repo is the project repo, you can `import fastreid` anywhere you want, and define customer operations if you like.
