### PR TITLE
Fix error caused by a missing default config value `FLIP_ENABLED`

### DIFF
--- a/fastreid/config/defaults.py
+++ b/fastreid/config/defaults.py
@@ -275,6 +275,9 @@ _C.TEST.PRECISE_BN.ENABLED = False
 _C.TEST.PRECISE_BN.DATASET = 'Market1501'
 _C.TEST.PRECISE_BN.NUM_ITER = 300
 
+# Get features with flipped images
+_C.TEST.FLIP_ENABLED = False
+
 # ---------------------------------------------------------------------------- #
 # Misc options
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
In the commit `66941cf27a68905a79bcb3fd6779dd9a9553e2a3`, the [code](https://github.com/JDAI-CV/fast-reid/blob/master/fastreid/engine/defaults.py#L476) in `fastreid/engine/defaults.py` line 476 attempt to call `inference_on_dataset` method with a parameter `flip_test=cfg.TEST.FLIP_ENABLED`:
```
results_i = inference_on_dataset(model, data_loader, evaluator, flip_test=cfg.TEST.FLIP_ENABLED)
```

But this config item has no default value in `fastreid/config/defaults.py` file, which may cause the error like:
```
[12/28 10:46:22] fastreid.engine.train_loop ERROR: Exception during training:
Traceback (most recent call last):
  File "./fastreid/engine/train_loop.py", line 147, in train
    self.after_epoch()
  File "./fastreid/engine/train_loop.py", line 181, in after_epoch
    h.after_epoch()
  File "./fastreid/engine/hooks.py", line 370, in after_epoch
    self._do_eval()
  File "./fastreid/engine/hooks.py", line 345, in _do_eval
    results = self._func()
  File "./fastreid/engine/defaults.py", line 336, in test_and_save_results
    self._last_eval_results = self.test(self.cfg, self.model)
  File "./fastreid/engine/defaults.py", line 476, in test
    results_i = inference_on_dataset(model, data_loader, evaluator, flip_test=cfg.TEST.FLIP_ENABLED)
  File "/path/to/lib/python3.7/site-packages/yacs/config.py", line 141, in __getattr__
    raise AttributeError(name)
AttributeError: FLIP_ENABLED
```

