### PR TITLE
Specify requirement.txt location in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@
 conda create -n fastreid python=3.7
 conda activate fastreid
 conda install pytorch==1.6.0 torchvision tensorboard -c pytorch
-pip install -r requirements
+pip install -r docs/requirements.txt
 ```
 
 # Set up with Dockder


### PR DESCRIPTION
Previously, it was hard to find the requirements.txt file. At first glance, I thought it wasn't provided in the repo.