### PR TITLE
update deployment toolchain

### DIFF
--- a/tools/deploy/caffe_export.py
+++ b/tools/deploy/caffe_export.py
@@ -19,12 +19,17 @@ from fastreid.utils.file_io import PathManager
 from fastreid.utils.checkpoint import Checkpointer
 from fastreid.utils.logger import setup_logger
 
+# import some modules added in project like this below
+# sys.path.append('../projects/FastCls')
+# from fastcls import *
+
 setup_logger(name='fastreid')
 logger = logging.getLogger("fastreid.caffe_export")
 
 
 def setup_cfg(args):
     cfg = get_cfg()
+    # add_cls_config(cfg)
     cfg.merge_from_file(args.config_file)
     cfg.merge_from_list(args.opts)
     cfg.freeze()
@@ -64,7 +69,8 @@ if __name__ == '__main__':
 
     cfg.defrost()
     cfg.MODEL.BACKBONE.PRETRAIN = False
-    cfg.MODEL.HEADS.POOL_LAYER = "identity"
+    if cfg.MODEL.HEADS.POOL_LAYER == 'fastavgpool':
+        cfg.MODEL.HEADS.POOL_LAYER = 'avgpool'
     cfg.MODEL.BACKBONE.WITH_NL = False
 
     model = build_model(cfg)

--- a/tools/deploy/onnx_export.py
+++ b/tools/deploy/onnx_export.py
@@ -21,6 +21,10 @@ from fastreid.utils.file_io import PathManager
 from fastreid.utils.checkpoint import Checkpointer
 from fastreid.utils.logger import setup_logger
 
+# import some modules added in project like this below
+# sys.path.append('../../projects/FastDistill')
+# from fastdistill import *
+
 logger = setup_logger(name='onnx_export')
 
 
@@ -49,6 +53,12 @@ def get_parser():
         "--output",
         default='onnx_model',
         help='path to save converted onnx model'
+    )
+    parser.add_argument(
+        '--batch-size',
+        default=1,
+        type=int,
+        help="the maximum batch size of onnx runtime"
     )
     parser.add_argument(
         "--opts",
@@ -130,7 +140,7 @@ if __name__ == '__main__':
     model.eval()
     logger.info(model)
 
-    inputs = torch.randn(1, 3, cfg.INPUT.SIZE_TEST[0], cfg.INPUT.SIZE_TEST[1])
+    inputs = torch.randn(args.batch_size, 3, cfg.INPUT.SIZE_TEST[0], cfg.INPUT.SIZE_TEST[1])
     onnx_model = export_onnx_model(model, inputs)
 
     model_simp, check = simplify(onnx_model)

--- a/tools/deploy/run_export.sh
+++ b/tools/deploy/run_export.sh
@@ -1,4 +1,0 @@
-python3 caffe_export.py --config-file /export/home/lxy/cvpalgo-fast-reid/projects/bjzProject/configs/r34.yml \
---name "r34-0603" \
---output logs/caffe_r34-0603 \
---opts MODEL.WEIGHTS /export/home/lxy/cvpalgo-fast-reid/logs/bjz/sbs_R34_bjz_0603_8x32/model_final.pth

--- a/tools/deploy/trt_calibrator.py
+++ b/tools/deploy/trt_calibrator.py
@@ -1,0 +1,102 @@
+# encoding: utf-8
+"""
+@author:  xingyu liao
+@contact: sherlockliao01@gmail.com
+
+Create custom calibrator, use to calibrate int8 TensorRT model.
+Need to override some methods of trt.IInt8EntropyCalibrator2, such as get_batch_size, get_batch,
+read_calibration_cache, write_calibration_cache.
+"""
+
+# based on:
+# https://github.com/qq995431104/Pytorch2TensorRT/blob/master/myCalibrator.py
+
+import os
+import sys
+
+import tensorrt as trt
+import pycuda.driver as cuda
+import pycuda.autoinit
+
+import numpy as np
+import torchvision.transforms as T
+
+sys.path.append('../..')
+
+from fastreid.data.build import _root
+from fastreid.data.data_utils import read_image
+from fastreid.data.datasets import DATASET_REGISTRY
+import logging
+
+from fastreid.data.transforms import ToTensor
+
+
+logger = logging.getLogger('trt_export.calibrator')
+
+
+class FeatEntropyCalibrator(trt.IInt8EntropyCalibrator2):
+
+    def __init__(self, args):
+        trt.IInt8EntropyCalibrator2.__init__(self)
+
+        self.cache_file = 'reid_feat.cache'
+
+        self.batch_size = args.batch_size
+        self.channel = args.channel
+        self.height = args.height
+        self.width = args.width
+        self.transform = T.Compose([
+            T.Resize((self.height, self.width), interpolation=3),  # [h,w]
+            ToTensor(),
+        ])
+
+        dataset = DATASET_REGISTRY.get(args.calib_data)(root=_root)
+        self._data_items = dataset.train + dataset.query + dataset.gallery
+        np.random.shuffle(self._data_items)
+        self.imgs = [item[0] for item in self._data_items]
+
+        self.batch_idx = 0
+        self.max_batch_idx = len(self.imgs) // self.batch_size
+
+        self.data_size = self.batch_size * self.channel * self.height * self.width * trt.float32.itemsize
+        self.device_input = cuda.mem_alloc(self.data_size)
+
+    def next_batch(self):
+        if self.batch_idx < self.max_batch_idx:
+            batch_files = self.imgs[self.batch_idx * self.batch_size:(self.batch_idx + 1) * self.batch_size]
+            batch_imgs = np.zeros((self.batch_size, self.channel, self.height, self.width),
+                                  dtype=np.float32)
+            for i, f in enumerate(batch_files):
+                img = read_image(f)
+                img = self.transform(img).numpy()
+                assert (img.nbytes == self.data_size // self.batch_size), 'not valid img!' + f
+                batch_imgs[i] = img
+            self.batch_idx += 1
+            logger.info("batch:[{}/{}]".format(self.batch_idx, self.max_batch_idx))
+            return np.ascontiguousarray(batch_imgs)
+        else:
+            return np.array([])
+
+    def get_batch_size(self):
+        return self.batch_size
+
+    def get_batch(self, names, p_str=None):
+        try:
+            batch_imgs = self.next_batch()
+            batch_imgs = batch_imgs.ravel()
+            if batch_imgs.size == 0 or batch_imgs.size != self.batch_size * self.channel * self.height * self.width:
+                return None
+            cuda.memcpy_htod(self.device_input, batch_imgs.astype(np.float32))
+            return [int(self.device_input)]
+        except:
+            return None
+
+    def read_calibration_cache(self):
+        # If there is a cache, use it instead of calibrating again. Otherwise, implicitly return None.
+        if os.path.exists(self.cache_file):
+            with open(self.cache_file, "rb") as f:
+                return f.read()
+
+    def write_calibration_cache(self, cache):
+        with open(self.cache_file, "wb") as f:
+            f.write(cache)

--- a/tools/deploy/trt_inference.py
+++ b/tools/deploy/trt_inference.py
@@ -6,15 +6,14 @@
 import argparse
 import glob
 import os
-import sys
 
 import cv2
 import numpy as np
+import pycuda.driver as cuda
+import tensorrt as trt
 import tqdm
 
-sys.path.append("/export/home/lxy/runtimelib-tensorrt-tiny/build")
-
-import pytrt
+TRT_LOGGER = trt.Logger()
 
 
 def get_parser():
@@ -37,8 +36,10 @@ def get_parser():
         help="path to save trt model inference results"
     )
     parser.add_argument(
-        "--output-name",
-        help="tensorRT model output name"
+        '--batch-size',
+        default=1,
+        type=int,
+        help='the maximum batch size of trt module'
     )
     parser.add_argument(
         "--height",
@@ -55,35 +56,134 @@ def get_parser():
     return parser
 
 
-def preprocess(image_path, image_height, image_width):
-    original_image = cv2.imread(image_path)
-    # the model expects RGB inputs
-    original_image = original_image[:, :, ::-1]
+class HostDeviceMem(object):
+    """ Host and Device Memory Package """
 
-    # Apply pre-processing to image.
-    img = cv2.resize(original_image, (image_width, image_height), interpolation=cv2.INTER_CUBIC)
-    img = img.astype("float32").transpose(2, 0, 1)[np.newaxis]  # (1, 3, h, w)
-    return img
+    def __init__(self, host_mem, device_mem):
+        self.host = host_mem
+        self.device = device_mem
+
+    def __str__(self):
+        return "Host:\n" + str(self.host) + "\nDevice:\n" + str(self.device)
+
+    def __repr__(self):
+        return self.__str__()
 
 
-def normalize(nparray, order=2, axis=-1):
-    """Normalize a N-D numpy array along the specified axis."""
-    norm = np.linalg.norm(nparray, ord=order, axis=axis, keepdims=True)
-    return nparray / (norm + np.finfo(np.float32).eps)
+class TrtEngine:
+
+    def __init__(self, trt_file=None, gpu_idx=0, batch_size=1):
+        cuda.init()
+        self._batch_size = batch_size
+        self._device_ctx = cuda.Device(gpu_idx).make_context()
+        self._engine = self._load_engine(trt_file)
+        self._context = self._engine.create_execution_context()
+        self._input, self._output, self._bindings, self._stream = self._allocate_buffers(self._context)
+
+    def _load_engine(self, trt_file):
+        """
+        Load tensorrt engine.
+        :param trt_file:    tensorrt file.
+        :return:
+            ICudaEngine
+        """
+        with open(trt_file, "rb") as f, \
+                trt.Runtime(TRT_LOGGER) as runtime:
+            engine = runtime.deserialize_cuda_engine(f.read())
+        return engine
+
+    def _allocate_buffers(self, context):
+        """
+        Allocate device memory space for data.
+        :param context:
+        :return:
+        """
+        inputs = []
+        outputs = []
+        bindings = []
+        stream = cuda.Stream()
+        for binding in self._engine:
+            size = trt.volume(self._engine.get_binding_shape(binding)) * self._engine.max_batch_size
+            dtype = trt.nptype(self._engine.get_binding_dtype(binding))
+            # Allocate host and device buffers
+            host_mem = cuda.pagelocked_empty(size, dtype)
+            device_mem = cuda.mem_alloc(host_mem.nbytes)
+            # Append the device buffer to device bindings.
+            bindings.append(int(device_mem))
+            # Append to the appropriate list.
+            if self._engine.binding_is_input(binding):
+                inputs.append(HostDeviceMem(host_mem, device_mem))
+            else:
+                outputs.append(HostDeviceMem(host_mem, device_mem))
+        return inputs, outputs, bindings, stream
+
+    def infer(self, data):
+        """
+        Real inference process.
+        :param model:   Model objects
+        :param data:    Preprocessed data
+        :return:
+            output
+        """
+        # Copy data to input memory buffer
+        [np.copyto(_inp.host, data.ravel()) for _inp in self._input]
+        # Push to device
+        self._device_ctx.push()
+        # Transfer input data to the GPU.
+        # cuda.memcpy_htod_async(self._input.device, self._input.host, self._stream)
+        [cuda.memcpy_htod_async(inp.device, inp.host, self._stream) for inp in self._input]
+        # Run inference.
+        self._context.execute_async_v2(bindings=self._bindings, stream_handle=self._stream.handle)
+        # Transfer predictions back from the GPU.
+        # cuda.memcpy_dtoh_async(self._output.host, self._output.device, self._stream)
+        [cuda.memcpy_dtoh_async(out.host, out.device, self._stream) for out in self._output]
+        # Synchronize the stream
+        self._stream.synchronize()
+        # Pop the device
+        self._device_ctx.pop()
+
+        return [out.host.reshape(self._batch_size, -1) for out in self._output[::-1]]
+
+    def inference_on_images(self, imgs, new_size=(256, 128)):
+        trt_inputs = []
+        for img in imgs:
+            input_ndarray = self.preprocess(img, *new_size)
+            trt_inputs.append(input_ndarray)
+        trt_inputs = np.vstack(trt_inputs)
+
+        valid_bsz = trt_inputs.shape[0]
+        if valid_bsz < self._batch_size:
+            trt_inputs = np.vstack([trt_inputs, np.zeros((self._batch_size - valid_bsz, 3, *new_size))])
+
+        result, = self.infer(trt_inputs)
+        result = result[:valid_bsz]
+        feat = self.postprocess(result, axis=1)
+        return feat
+
+    @classmethod
+    def preprocess(cls, img, img_height, img_width):
+        # Apply pre-processing to image.
+        resize_img = cv2.resize(img, (img_width, img_height), interpolation=cv2.INTER_CUBIC)
+        type_img = resize_img.astype("float32").transpose(2, 0, 1)[np.newaxis]  # (1, 3, h, w)
+        return type_img
+
+    @classmethod
+    def postprocess(cls, nparray, order=2, axis=-1):
+        """Normalize a N-D numpy array along the specified axis."""
+        norm = np.linalg.norm(nparray, ord=order, axis=axis, keepdims=True)
+        return nparray / (norm + np.finfo(np.float32).eps)
+
+    def __del__(self):
+        del self._input
+        del self._output
+        del self._stream
+        self._device_ctx.detach()  # release device context
 
 
 if __name__ == "__main__":
     args = get_parser().parse_args()
 
-    trt = pytrt.Trt()
-
-    onnxModel = ""
-    engineFile = args.model_path
-    customOutput = []
-    maxBatchSize = 1
-    calibratorData = []
-    mode = 2
-    trt.CreateEngine(onnxModel, engineFile, customOutput, maxBatchSize, mode, calibratorData)
+    trt = TrtEngine(args.model_path, batch_size=args.batch_size)
 
     if not os.path.exists(args.output): os.makedirs(args.output)
 
@@ -91,9 +191,10 @@ if __name__ == "__main__":
         if os.path.isdir(args.input[0]):
             args.input = glob.glob(os.path.expanduser(args.input[0]))
             assert args.input, "The input path(s) was not found"
-        for path in tqdm.tqdm(args.input):
-            input_numpy_array = preprocess(path, args.height, args.width)
-            trt.DoInference(input_numpy_array)
-            feat = trt.GetOutput(args.output_name)
-            feat = normalize(feat, axis=1)
-            np.save(os.path.join(args.output, path.replace('.jpg', '.npy').split('/')[-1]), feat)
+        inputs = []
+        for img_path in tqdm.tqdm(args.input):
+            img = cv2.imread(img_path)
+            # the model expects RGB inputs
+            cvt_img = img[:, :, ::-1]
+            feat = trt.inference_on_images([cvt_img])
+            np.save(os.path.join(args.output, os.path.basename(img_path) + '.npy'), feat[0])


### PR DESCRIPTION
Summary:
Remove tiny-tensorrt dependency and rewrite a new tensorrt inference api.
In the new version of trt infer, it can pad the input to fixed batch automatically, so you don't need to worry about dynamic batch size.