### PR TITLE
Fix bug: COMBINEALL should add extra prefix to avoid pid conflictions

### DIFF
--- a/fastreid/data/datasets/bases.py
+++ b/fastreid/data/datasets/bases.py
@@ -102,8 +102,8 @@ class Dataset(object):
             for img_path, pid, camid in data:
                 if pid in self._junk_pids:
                     continue
-                pid = self.dataset_name + "_" + str(pid)
-                camid = self.dataset_name + "_" + str(camid)
+                pid = self.dataset_name + "_test_" + str(pid)
+                camid = self.dataset_name + "_test_" + str(camid)
                 combined.append((img_path, pid, camid))
 
         _combine_data(self.query)


### PR DESCRIPTION
For datasets like CUHK03, train set and test set have some common pids (exactly, 377 pids), but the person identities are totally different. When combining the subsets into a larger one, extra prefix should be added to distinguish training samples from the testing ones.

Thanks @hzphzp to point out this.