### PR TITLE
Fix Error: TypeError: can't convert cuda:0 device type tensor to numpy.

### DIFF
--- a/demo/visualize_result.py
+++ b/demo/visualize_result.py
@@ -124,7 +124,7 @@ if __name__ == '__main__':
 
     # compute cosine distance
     distmat = 1 - torch.mm(q_feat, g_feat.t())
-    distmat = distmat.numpy()
+    distmat = distmat.cpu().numpy()
 
     logger.info("Computing APs for all query images ...")
     cmc, all_ap, all_inp = evaluate_rank(distmat, q_pids, g_pids, q_camids, g_camids)


### PR DESCRIPTION
Fix Error: TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.