### PR TITLE
convert type of camids (imgid) from string to int

### DIFF
--- a/fastreid/data/datasets/vehicleid.py
+++ b/fastreid/data/datasets/vehicleid.py
@@ -62,6 +62,10 @@ class VehicleID(ImageDataset):
             if is_train:
                 vid = self.dataset_name + '_' + str(vid)
             dataset.append((img_path, vid, imgid))
+            
+        # convert type of camids (imgid) from string to int
+        for idx, sample in enumerate(dataset):
+            dataset[idx] = (sample[0], sample[1], idx)
 
         if is_train: return dataset
         else:


### PR DESCRIPTION
Seem that pytorch does not convert list of string to Tensor auto, which will causing error  "AttributeError: 'list' object has no attribute 'to'" in [here](https://github.com/JDAI-CV/fast-reid/blob/f2286e7f55524c6e13748fe70c80ef99b84f80fe/fastreid/evaluation/reid_evaluation.py#L43). 

But it is okay if I use a list of int here! So I have added several lines here and submitted my second PR. Thanks!