### PR TITLE
Fixed: set default type for parser

### DIFF
--- a/demo/visualize_result.py
+++ b/demo/visualize_result.py
@@ -72,6 +72,7 @@ def get_parser():
     )
     parser.add_argument(
         "--num-vis",
+        type=int,
         default=100,
         help="number of query images to be visualized",
     )
@@ -87,6 +88,7 @@ def get_parser():
     )
     parser.add_argument(
         "--max-rank",
+        type=int,
         default=10,
         help="maximum number of rank list to be visualized",
     )


### PR DESCRIPTION
The value will be treated as `str` if there is no type. Then there will be error
```
Traceback (most recent call last):
  File "demo/visualize_result.py", line 144, in <module>
    query_indices = visualizer.vis_rank_list(args.output, args.vis_label, args.num_vis, args.rank_sort, args.label_sort, args.max_rank)
  File "./fastreid/utils/visualizer.py", line 158, in vis_rank_list
    query_indices = query_indices[:num_vis]
TypeError: slice indices must be integers or None or have an __index__ method
```
when we add some custom parameter, such as `--num-vis 5`