### PR TITLE
Bug for custom input image size fix

### DIFF
--- a/tools/deploy/trt_inference.py
+++ b/tools/deploy/trt_inference.py
@@ -196,5 +196,5 @@ if __name__ == "__main__":
             img = cv2.imread(img_path)
             # the model expects RGB inputs
             cvt_img = img[:, :, ::-1]
-            feat = trt.inference_on_images([cvt_img])
+            feat = trt.inference_on_images([cvt_img], (args.height,args.width))
             np.save(os.path.join(args.output, os.path.basename(img_path).split('.')[0] + '.npy'), feat)


### PR DESCRIPTION
When the input image size is changed for the model, it is constant in trt_inference.py