### PR TITLE
optimize jaccard distance computation and the ranking

### DIFF
--- a/fastreid/evaluation/rank.py
+++ b/fastreid/evaluation/rank.py
@@ -81,8 +81,7 @@ def eval_cuhk03(distmat, q_pids, g_pids, q_camids, g_camids, max_rank):
         # compute AP
         num_rel = raw_cmc.sum()
         tmp_cmc = raw_cmc.cumsum()
-        tmp_cmc = [x / (i + 1.) for i, x in enumerate(tmp_cmc)]
-        tmp_cmc = np.asarray(tmp_cmc) * raw_cmc
+        tmp_cmc = (tmp_cmc/np.arange(1,len(tmp_cmc)+1)) * raw_cmc
         AP = tmp_cmc.sum() / num_rel
         all_AP.append(AP)
         num_valid_q += 1.


### PR DESCRIPTION
- I run a line_profiler on the ranking function and discovered that the line I modified takes 91.4 of the run time of the rank function. By modifying we can save a lot of ranking time.
- For the Jaccard distance, the code is performing a lot of not-needed computation that is increasing the reranking time. 