### PR TITLE
Debugged a torchvision version problem

### DIFF
--- a/fastreid/modeling/backbones/mobilenetv3.py
+++ b/fastreid/modeling/backbones/mobilenetv3.py
@@ -4,7 +4,15 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 import torch
 from torch import nn, Tensor
 from torch.nn import functional as F
-from torchvision.models.utils import load_state_dict_from_url
+
+#The style of importing Considers compatibility for the diversity of torchvision versions
+try:
+    from torchvision.models.utils import load_state_dict_from_url
+except ImportError:
+    try:
+        from torch.hub import load_state_dict_from_url
+    except ImportError:
+        from torch.utils.model_zoo import load_url as load_state_dict_from_url
 
 from fastreid.layers import get_norm
 from .build import BACKBONE_REGISTRY


### PR DESCRIPTION
In the current version of repo, line 7 at file "fastreid/modeling/backbones/mobilenetv3.py", the code writes as `from torchvision.models.utils import load_state_dict_from_url`. However, `torchvision.models` no longer includes `utils` in the latest versions. Instead, the `load_state_dict_from_url` function is at `torch.hub`, or as `load_url` in `torch.utils.model_zoo`. 
I've changed this import code to a "try-except" style of defensive code for compatibility of variaties of torch versions, helping customers avoid the torch-version-selecting issue.