### PR TITLE
Update build.py

### DIFF
--- a/fastreid/data/transforms/build.py
+++ b/fastreid/data/transforms/build.py
@@ -80,13 +80,13 @@ def build_transforms(cfg, is_train=True):
         if do_affine:
             res.append(T.RandomAffine(degrees=10, translate=None, scale=[0.9, 1.1], shear=0.1, resample=False,
                                       fillcolor=0))
-        if do_augmix:
-            res.append(AugMix(prob=augmix_prob))
+#         if do_augmix:
+#             res.append(AugMix(prob=augmix_prob))
         res.append(ToTensor())
         if do_rea:
             res.append(T.RandomErasing(p=rea_prob, value=rea_value))
-        if do_rpt:
-            res.append(RandomPatch(prob_happen=rpt_prob))
+#         if do_rpt:
+#             res.append(RandomPatch(prob_happen=rpt_prob))
     else:
         size_test = cfg.INPUT.SIZE_TEST
         do_crop = cfg.INPUT.CROP.ENABLED


### PR DESCRIPTION
训练过程中，内存一直增长，到后期会把整个服务器的内存都占完，初步分析将上述两个增强关闭后，内存使用会正常，具体是因为哪个方法，因为哪个实现有问题，暂时还没有时间分析