### PR TITLE
Fix docker build and Update documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,4 +25,5 @@ pip install -r docs/requirements.txt
 ```
 
 # Set up with Dockder
-comming soon
+
+Please check the [docker folder](docker)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM nvidia/cuda:10.1-cudnn7-devel
 
+# https://github.com/NVIDIA/nvidia-docker/issues/1632
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
 	python3-opencv ca-certificates python3-dev git wget sudo ninja-build
@@ -12,8 +15,9 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER appuser
 WORKDIR /home/appuser
 
+# https://github.com/facebookresearch/detectron2/issues/3933
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN wget https://bootstrap.pypa.io/get-pip.py && \
+RUN wget https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
 	python3 get-pip.py --user && \
 	rm get-pip.py
 


### PR DESCRIPTION
The docker build is broken with the following two errors:
1. public key out of date
```W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
```
2. boostrap incompatibility
```
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
The command '/bin/sh -c wget https://bootstrap.pypa.io/get-pip.py && 	python3 get-pip.py --user && 	rm get-pip.py' returned a non-zero code: 1
```

This PR is to fix the both and reference link as the comment. I also modified the INSTALL.md to link the docker folder. In many cases, docker is easier than conda as we can use different cuda versions.