### PR TITLE
Resolving Errors

### DIFF
--- a/fastreid/data/build.py
+++ b/fastreid/data/build.py
@@ -16,7 +16,7 @@ if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
 else:
     string_classes = str
 
-from collections import Mapping
+from collections.abc import Mapping
 
 from fastreid.config import configurable
 from fastreid.utils import comm

--- a/fastreid/evaluation/testing.py
+++ b/fastreid/evaluation/testing.py
@@ -2,7 +2,8 @@
 import logging
 import pprint
 import sys
-from collections import Mapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import Mapping
 
 import numpy as np
 from tabulate import tabulate


### PR DESCRIPTION
there was a change in Python 3.10 and the Mapping class has been moved to the collections.abc module. So, if you're using Python 3.10 or later, you should import the Mapping class from the collections.abc module, not the collections module