### PR TITLE
fix: typo. import evaluation_rank from evaluation.rank

### DIFF
--- a/demo/visualize_result.py
+++ b/demo/visualize_result.py
@@ -15,7 +15,7 @@ from torch.backends import cudnn
 
 sys.path.append('.')
 
-from fastreid.evaluation import evaluate_rank
+from fastreid.evaluation.rank import evaluate_rank
 from fastreid.config import get_cfg
 from fastreid.utils.logger import setup_logger
 from fastreid.data import build_reid_test_loader


### PR DESCRIPTION
I think there's a typo.
from fastreid.evaluation import evaluate_rank -> from fastreid.evaluation.rank import evaluate_rank